### PR TITLE
Limited push trigger to main branch only

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,11 @@
 name: .NET Build and Test
 
-on: [push, pull_request, workflow_dispatch]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build_web:


### PR DESCRIPTION
Workflow is still triggered by pull request, and can still be triggered manually. This closes #10 