### PR TITLE
Use interfaces across the complete infrastructure layer

### DIFF
--- a/src/Chirp.Core/Interfaces/IAuthorRepository.cs
+++ b/src/Chirp.Core/Interfaces/IAuthorRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Chirp.Core.DTOs;
+using Microsoft.AspNetCore.Http;
 
 namespace Chirp.Core.Interfaces;
 
@@ -6,11 +7,14 @@ public interface IAuthorRepository
 {
     Task<AuthorDTO?> FindAuthorByNameDTO(String name);
     Task<Author?> FindAuthorByName(String name);
-    Task CreateAuthor(string authorName, string authorEmail, string profilePicture);
+    Task CreateAuthor(string authorName, string authorEmail, string? profilePicture);
     Task DeleteUser(AuthorDTO author);
     Task FollowAuthor(string userAuthor, string followedAuthor);
     Task UnfollowAuthor(string userAuthor, string authorToBeRemoved);
     Task RemovedAuthorFromFollowingList(string authorName);
     Task<List<string>> GetFollowedAuthors(string userName);
     Task<int> GetKarmaForAuthor(string authorName);
+    Task<List<string>> GetFollowingAuthors(string userName);
+    Task UpdateProfilePicture(string authorName, IFormFile profilePicture);
+    Task ClearProfilePicture(string authorName, IFormFile profilePicture);
 }

--- a/src/Chirp.Core/Interfaces/IAuthorService.cs
+++ b/src/Chirp.Core/Interfaces/IAuthorService.cs
@@ -6,7 +6,7 @@ namespace Chirp.Core.Interfaces;
 public interface IAuthorService
 {
     public Task<AuthorDTO?> FindAuthorByName(String name);
-    public Task CreateAuthor(string authorName, string authorEmail, string? profilePicture = null);
+    public Task CreateAuthor(string authorName, string authorEmail, string? profilePicture);
     public Task DeleteUser(AuthorDTO Author);
     public Task FollowAuthor(string userAuthorName, string followedAuthorName);
     public Task UnfollowAuthor(string userAuthor, string authorToBeRemoved);

--- a/src/Chirp.Core/Interfaces/ICheepRepository.cs
+++ b/src/Chirp.Core/Interfaces/ICheepRepository.cs
@@ -7,6 +7,7 @@ public interface ICheepRepository
 {
     Task<List<CheepDTO>> ReadCheepsFromAuthor(string userName, int page);
     Task<List<CheepDTO>> ReadAllCheeps(int page);
+    Task<List<CheepDTO>> ReadPrivateCheeps(int page, string username);
     Task CreateCheep(CheepDTO newCheep);
     Task UpdateCheep(CheepDTO alteredCheep);
     Task<int> GetTotalPages(string authorName);
@@ -16,4 +17,14 @@ public interface ICheepRepository
     Task<int> GetTotalPageNumberForPopular();
     Task<string> HandleImageUpload(IFormFile image);
     Task<List<CheepDTO>> GetMessagesForSimulator(string? username = null, int count = 100);
+    Task<List<CheepDTO>> RetrieveAllCheepsForEndPoint();
+    Task<List<CheepDTO>> RetrieveAllCheepsFromAnAuthor(string Username);
+    Task DeleteComment(int commentId);
+    Task HandleLike(string authorName, int cheepId, string? emoji = null);
+    Task HandleDislike(string authorName, int cheepId, string? emoji = null);
+    Task<List<CommentDTO>> GetCommentsByCheepId(int cheepId);
+    Task AddCommentToCheep(CheepDTO cheepDto, string text, string author);
+    Task<CheepDTO> GetCheepFromId(int cheepId);
+    Task<List<String>> GetTopReactions(int cheepId, int topN = 3);
+    Task<List<CommentDTO>> RetriveAllCommentsFromAnAuthor(string Username);
 }

--- a/src/Chirp.Core/Interfaces/ICheepService.cs
+++ b/src/Chirp.Core/Interfaces/ICheepService.cs
@@ -8,7 +8,7 @@ public interface ICheepService
     public Task<List<Core.DTOs.CheepDTO>> GetCheeps(int page);
     public Task<List<Core.DTOs.CheepDTO>> GetCheepsFromAuthor(string author, int page);
     
-    public Task<int> GetTotalPageNumber(string authorName);
+    public Task<int> GetTotalPageNumber(string authorName  = "");
     
     public Task<List<Core.DTOs.CheepDTO>> RetrieveAllCheeps();
     
@@ -25,4 +25,12 @@ public interface ICheepService
     public Task<string> HandleImageUpload(IFormFile image);
     
     Task<List<CheepDTO>> GetMessagesForSimulator(string? username = null, int count = 100);
+    Task<CheepDTO?> GetCheepFromId(int cheepId);
+    Task<List<CommentDTO>> GetCommentsByCheepId(int cheepId);
+    Task AddCommentToCheep(CheepDTO cheepDto, string Text, string author);
+    Task DeleteComment(int commentId);
+    Task<List<Core.DTOs.CheepDTO>> GetPrivateCheeps(int page, string username);
+    Task<List<String>> GetTopReactions(int cheepId);
+    Task DeleteCheep(int cheepId);
+    Task<List<Core.DTOs.CommentDTO>> RetrieveAllCommentsFromAnAuthor(string authorName);
 }

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -18,9 +18,9 @@ namespace Chirp.Infrastructure.Repositories
     public class CheepRepository : ICheepRepository
     {
         private readonly CheepDBContext _dbContext;
-        private readonly AuthorRepository _authorRepository;
+        private readonly IAuthorRepository _authorRepository;
 
-        public CheepRepository(CheepDBContext dbContext, AuthorRepository authorRepository)
+        public CheepRepository(CheepDBContext dbContext, IAuthorRepository authorRepository)
         {
             _dbContext = dbContext;
             _authorRepository = authorRepository;

--- a/src/Chirp.Infrastructure/Services/AuthorService.cs
+++ b/src/Chirp.Infrastructure/Services/AuthorService.cs
@@ -8,9 +8,9 @@ namespace Chirp.Infrastructure.Services;
 public class AuthorService : IAuthorService
 {
     
-    private readonly AuthorRepository _authorRepository;
+    private readonly IAuthorRepository _authorRepository;
     
-    public AuthorService(AuthorRepository authorRepository)
+    public AuthorService(IAuthorRepository authorRepository)
     {
         _authorRepository = authorRepository;
     }

--- a/src/Chirp.Infrastructure/Services/CheepService.cs
+++ b/src/Chirp.Infrastructure/Services/CheepService.cs
@@ -7,9 +7,9 @@ namespace Chirp.Infrastructure.Services;
 
 public class CheepService : ICheepService
 {
-    private readonly CheepRepository _cheepRepository;
-    private readonly AuthorRepository _authorRepository;
-    public CheepService(CheepRepository cheepRepository, AuthorRepository authorRepository)
+    private readonly ICheepRepository _cheepRepository;
+    private readonly IAuthorRepository _authorRepository;
+    public CheepService(ICheepRepository cheepRepository, IAuthorRepository authorRepository)
     {
         _cheepRepository = cheepRepository;
         _authorRepository = authorRepository;

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading;
 using System.Threading.Tasks;
+using Chirp.Core.Interfaces;
 using Chirp.Infrastructure.Data;
 using Chirp.Infrastructure.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -31,14 +32,14 @@ namespace Chirp.Web.Areas.Identity.Pages.Account
         private readonly IUserStore<ApplicationUser> _userStore;
         private readonly IUserEmailStore<ApplicationUser> _emailStore;
         private readonly ILogger<ExternalLoginModel> _logger;
-        private readonly AuthorService _authorService;
+        private readonly IAuthorService _authorService;
 
         public ExternalLoginModel(
             SignInManager<ApplicationUser> signInManager,
             UserManager<ApplicationUser> userManager,
             IUserStore<ApplicationUser> userStore,
             ILogger<ExternalLoginModel> logger,
-            AuthorService authorService)
+            IAuthorService authorService)
         {
             _signInManager = signInManager;
             _userManager = userManager;

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalCheeps.cshtml.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalCheeps.cshtml.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using Chirp.Core.DTOs;
+using Chirp.Core.Interfaces;
 using Chirp.Infrastructure.Data;
 using Chirp.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
@@ -17,14 +18,14 @@ namespace Chirp.Web.Areas.Identity.Pages.Account.Manage
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly ILogger<DeletePersonalDataModel> _logger;
-        private readonly CheepService _service;
+        private readonly ICheepService _service;
         
 
         public DeletePersonalCheepsModel(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
             ILogger<DeletePersonalDataModel> logger,
-            CheepService service)
+            ICheepService service)
         {
             _userManager = userManager;
             _signInManager = signInManager;

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using Chirp.Core.DTOs;
+using Chirp.Core.Interfaces;
 using Chirp.Infrastructure.Data;
 using Chirp.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
@@ -17,16 +18,16 @@ namespace Chirp.Web.Areas.Identity.Pages.Account.Manage
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly ILogger<DeletePersonalDataModel> _logger;
-        private readonly CheepService _cheepService;
-        private readonly AuthorService _authorService;
+        private readonly ICheepService _cheepService;
+        private readonly IAuthorService _authorService;
         
 
         public DeletePersonalDataModel(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
             ILogger<DeletePersonalDataModel> logger,
-            CheepService cheepService,
-            AuthorService authorService)
+            ICheepService cheepService,
+            IAuthorService authorService)
         {
             _userManager = userManager;
             _signInManager = signInManager;

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.cshtml.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.cshtml.cs
@@ -6,6 +6,7 @@
 
 using System.IO.Compression;
 using System.Text;
+using Chirp.Core.Interfaces;
 using Chirp.Infrastructure.Data;
 using Chirp.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
@@ -20,14 +21,14 @@ namespace Chirp.Web.Areas.Identity.Pages.Account.Manage
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly ILogger<DownloadPersonalDataModel> _logger;
-        private readonly CheepService _cheepService;
-        private readonly AuthorService _authorService;
+        private readonly ICheepService _cheepService;
+        private readonly IAuthorService _authorService;
 
         public DownloadPersonalDataModel(
             UserManager<ApplicationUser> userManager,
             ILogger<DownloadPersonalDataModel> logger,
-            CheepService cheepService,
-            AuthorService authorService)
+            ICheepService cheepService,
+            IAuthorService authorService)
         {
             _userManager = userManager;
             _logger = logger;

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
@@ -8,6 +8,7 @@ using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Chirp.Core;
 using Chirp.Core.DTOs;
+using Chirp.Core.Interfaces;
 using Chirp.Infrastructure.Data;
 using Chirp.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
@@ -20,20 +21,17 @@ namespace Chirp.Web.Areas.Identity.Pages.Account.Manage
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
-        private readonly CheepService _cheepService;
-        private readonly AuthorService _authorService;
+        private readonly IAuthorService _authorService;
         
         public AuthorDTO UserAuthor { get; set; }
 
         public IndexModel(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
-            CheepService cheepService,
-            AuthorService authorService)
+            IAuthorService authorService)
         {
             _userManager = userManager;
             _signInManager = signInManager;
-            _cheepService = cheepService;
             _authorService = authorService;
         }
 

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/PersonalData.cshtml.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/PersonalData.cshtml.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Chirp.Core.DTOs;
+using Chirp.Core.Interfaces;
 using Chirp.Infrastructure.Data;
 using Chirp.Infrastructure.Services;
 using Chirp.Web.Pages.Views;
@@ -18,8 +19,8 @@ namespace Chirp.Web.Areas.Identity.Pages.Account.Manage
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly ILogger<PersonalDataModel> _logger;
-        private readonly CheepService _cheepService;
-        private readonly AuthorService _authorService;
+        private readonly ICheepService _cheepService;
+        private readonly IAuthorService _authorService;
         public int PageNumber { get; set; }
         public int TotalPageNumber { get; set; }
         public SharedChirpViewModel SharedViewModel { get; set; } = new SharedChirpViewModel();
@@ -32,8 +33,8 @@ namespace Chirp.Web.Areas.Identity.Pages.Account.Manage
         public PersonalDataModel(
             UserManager<ApplicationUser> userManager,
             ILogger<PersonalDataModel> logger, 
-            CheepService cheepService,
-            AuthorService authorService)
+            ICheepService cheepService,
+            IAuthorService authorService)
         {
             _userManager = userManager;
             _logger = logger;

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 #nullable disable
 using System.ComponentModel.DataAnnotations;
+using Chirp.Core.Interfaces;
 using Chirp.Infrastructure.Data;
 using Chirp.Infrastructure.Services;
 using Microsoft.AspNetCore.Authentication;
@@ -19,14 +20,14 @@ namespace Chirp.Web.Areas.Identity.Pages.Account
         private readonly IUserStore<ApplicationUser> _userStore;
         private readonly IUserEmailStore<ApplicationUser> _emailStore;
         private readonly ILogger<RegisterModel> _logger;
-        private readonly AuthorService _authorService;
+        private readonly IAuthorService _authorService;
 
         public RegisterModel(
             UserManager<ApplicationUser> userManager,
             IUserStore<ApplicationUser> userStore,
             SignInManager<ApplicationUser> signInManager,
             ILogger<RegisterModel> logger,
-            AuthorService authorService)
+            IAuthorService authorService)
         {
             _userManager = userManager;
             _userStore = userStore;
@@ -128,7 +129,7 @@ namespace Chirp.Web.Areas.Identity.Pages.Account
                 {
                     _logger.LogInformation("User created a new account with password.");
                         
-                    await _authorService.CreateAuthor(Input.UserName, Input.Email);
+                    await _authorService.CreateAuthor(Input.UserName, Input.Email, null);
                     
                     await _signInManager.SignInAsync(user, isPersistent: false);
                     return LocalRedirect(returnUrl);

--- a/src/Chirp.Web/Controllers/SimulatorController.cs
+++ b/src/Chirp.Web/Controllers/SimulatorController.cs
@@ -21,8 +21,8 @@ public class SimulatorController : ControllerBase
     
     public SimulatorController(
         ILatestService latestService,
-        AuthorService authorService,
-        CheepService cheepService)
+        IAuthorService authorService,
+        ICheepService cheepService)
     {
         _latestService = latestService;
         _authorService = authorService;
@@ -106,7 +106,7 @@ public class SimulatorController : ControllerBase
             }
             
             // Create the author
-            await _authorService.CreateAuthor(request.Username, request.Email);
+            await _authorService.CreateAuthor(request.Username, request.Email, null);
             
             return NoContent();
         }

--- a/src/Chirp.Web/Pages/CheepComment.cshtml.cs
+++ b/src/Chirp.Web/Pages/CheepComment.cshtml.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
 using Chirp.Core.DTOs;
+using Chirp.Core.Interfaces;
 using Chirp.Infrastructure.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -10,8 +11,8 @@ namespace Chirp.Web.Pages;
 
 public class CheepCommentModel : PageModel
 {
-    private readonly CheepService _cheepService;
-    private readonly AuthorService _authorService;
+    private readonly ICheepService _cheepService;
+    private readonly IAuthorService _authorService;
     public int PageNumber { get; set; }
     public int TotalPageNumber { get; set; }
     public required List<CommentDTO> Comments { get; set; }
@@ -24,7 +25,7 @@ public class CheepCommentModel : PageModel
     [StringLength(160, ErrorMessage = "Maximum length is {1} characters")]
     public string CommentText { get; set; } = string.Empty;
     
-    public CheepCommentModel(CheepService cheepService, AuthorService authorService)
+    public CheepCommentModel(ICheepService cheepService, IAuthorService authorService)
     {
         _cheepService = cheepService;
         _authorService = authorService;

--- a/src/Chirp.Web/Pages/PopularTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/PopularTimeline.cshtml.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Chirp.Core.DTOs;
+using Chirp.Core.Interfaces;
 using Chirp.Infrastructure.Services;
 using Chirp.Web.Pages.Views;
 using Microsoft.AspNetCore.Mvc;
@@ -12,8 +13,8 @@ namespace Chirp.Web.Pages;
 
 public class PopularTimelineModel : PageModel
 {
-    private readonly CheepService _cheepService;
-    private readonly AuthorService _authorService;
+    private readonly ICheepService _cheepService;
+    private readonly IAuthorService _authorService;
     public int PageNumber { get; set; }
     public int TotalPageNumber { get; set; }
     public AuthorDTO? UserAuthor { get; set; }
@@ -23,7 +24,7 @@ public class PopularTimelineModel : PageModel
 
     public SharedChirpViewModel SharedChirpView { get; set; } = new SharedChirpViewModel();
 
-    public PopularTimelineModel(CheepService cheepService, AuthorService authorService)
+    public PopularTimelineModel(ICheepService cheepService, IAuthorService authorService)
     {
         _cheepService = cheepService;
         _authorService = authorService;

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Chirp.Core.DTOs;
+using Chirp.Core.Interfaces;
 using Chirp.Infrastructure.Services;
 using Chirp.Web.Pages.Views;
 using Microsoft.AspNetCore.Mvc;
@@ -12,8 +13,8 @@ namespace Chirp.Web.Pages;
 
 public class PublicModel : PageModel
 {
-    private readonly CheepService _cheepService;
-    private readonly AuthorService _authorService;
+    private readonly ICheepService _cheepService;
+    private readonly IAuthorService _authorService;
     public int PageNumber { get; set; }
     public int TotalPageNumber { get; set; }
     public AuthorDTO? UserAuthor { get; set; } 
@@ -23,7 +24,7 @@ public class PublicModel : PageModel
     public required List<CheepDTO> Cheeps { get; set; } = new List<CheepDTO>();
     public SharedChirpViewModel SharedChirpView { get; set; } = new SharedChirpViewModel();
 
-    public PublicModel(CheepService cheepService, AuthorService authorService)
+    public PublicModel(ICheepService cheepService, IAuthorService authorService)
     {
         _cheepService = cheepService;
         _authorService = authorService;

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -3,6 +3,7 @@ using Chirp.Core;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Chirp.Core.DTOs;
+using Chirp.Core.Interfaces;
 using Chirp.Infrastructure.Services;
 using Chirp.Web.Pages.Views;
 using Microsoft.AspNetCore.Mvc;
@@ -13,8 +14,8 @@ namespace Chirp.Web.Pages;
 
 public class UserTimelineModel : PageModel
 {
-    private readonly CheepService _cheepService;
-    private readonly AuthorService _authorService;
+    private readonly ICheepService _cheepService;
+    private readonly IAuthorService _authorService;
     public int PageNumber { get; set; }
     public int TotalPageNumber { get; set; }
     public int AuthorKarma { get; set; }
@@ -28,7 +29,7 @@ public class UserTimelineModel : PageModel
     public AuthorDTO? PageAuthor { get; set; }
     public AuthorDTO? UserAuthor { get; set; }
 
-    public UserTimelineModel(CheepService cheepService, AuthorService authorService)
+    public UserTimelineModel(ICheepService cheepService, IAuthorService authorService)
     {
         _cheepService = cheepService;
         _authorService = authorService;

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -52,11 +52,11 @@ namespace Chirp.Web
             builder.Services.AddSession();
             
             // Register your repositories and services
-            builder.Services.AddScoped<CheepRepository>();
-            builder.Services.AddScoped<AuthorRepository>();
+            builder.Services.AddScoped<ICheepRepository, CheepRepository>();
+            builder.Services.AddScoped<IAuthorRepository, AuthorRepository>();
             builder.Services.AddScoped<ILatestRepository, LatestRepository>();
-            builder.Services.AddScoped<CheepService>();
-            builder.Services.AddScoped<AuthorService>();
+            builder.Services.AddScoped<ICheepService, CheepService>();
+            builder.Services.AddScoped<IAuthorService, AuthorService>();
             builder.Services.AddScoped<ILatestService, LatestService>();
 
             // Build the application
@@ -123,13 +123,13 @@ namespace Chirp.Web
             // Map Controllers (Used for Simulator API endpoints)
             app.MapControllers();
             
-            app.MapGet("/cheeps", async (CheepService cheepService) =>
+            app.MapGet("/cheeps", async (ICheepService cheepService) =>
             {
                 var cheeps = await cheepService.RetrieveAllCheeps();
                 return Results.Ok(cheeps);
             });
             
-            app.MapGet("/{userName}/follows", async (string userName, AuthorService authorService) =>
+            app.MapGet("/{userName}/follows", async (string userName, IAuthorService authorService) =>
             {
                 var followedAuthors = await authorService.GetFollowedAuthors(userName);
                 return Results.Ok(followedAuthors);


### PR DESCRIPTION
# Refactor: Interfaces and Extended Author/Cheep Functionality

This PR improves abstraction and extensibility in the Chirp application, focusing on the Author and Cheep domains. It replaces concrete implementations with interfaces.
This pull request solves this issue: #14

---

## Improved Abstraction & Dependency Injection

- Replaced concrete classes (`AuthorService`, `CheepService`, `AuthorRepository`, `CheepRepository`) with their interfaces:
  - `IAuthorService`
  - `ICheepService`
  - `IAuthorRepository`
  - `ICheepRepository`
- Updated constructors and fields across controllers, Razor Pages, and services.
- Improves testability, flexibility, and adherence to clean architecture principles.

---

## Expanded Repository & Service Contracts

### Cheeps

Added methods to `ICheepRepository` and `ICheepService` to support using abstract interfaces instead of concrete implementations:

- Comments
- Reactions (likes/dislikes with emojis)
- Retrieving cheeps by ID
- Private cheeps
- Top reactions

### Authors

The same goes for `IAuthorRepository` with added methods for:

- Uploading and clearing profile pictures
- Retrieving followed authors
- Updating `CreateAuthor` to accept a nullable profile picture

`IAuthorService` and related usages were updated accordingly.

---

## Web Layer Updates

- Updated Razor Pages and controllers to depend on interfaces instead of concrete implementations.
- Ensures consistent use of abstractions across the application.