### PR TITLE
Convert stored UTC timestamps to local time

### DIFF
--- a/src/Chirp.Web/Pages/CheepComment.cshtml.cs
+++ b/src/Chirp.Web/Pages/CheepComment.cshtml.cs
@@ -45,7 +45,10 @@ public class CheepCommentModel : PageModel
         // Format the timestamp
         var CurrentTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow,TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"));
         
-        var timeDifference = CurrentTime - timeStampDateTime;
+        // Convert the parsed timestamp from UTC to local time (it's stored as UTC)
+        var localTimeStamp = TimeZoneInfo.ConvertTimeFromUtc(timeStampDateTime, TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"));
+        
+        var timeDifference = CurrentTime - localTimeStamp;
         
         if (timeDifference.TotalSeconds < 60)
         {

--- a/src/Chirp.Web/Pages/PopularTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/PopularTimeline.cshtml.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿﻿using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Chirp.Core.DTOs;
@@ -205,7 +205,10 @@ public class PopularTimelineModel : PageModel
         // Format the timestamp
         var CurrentTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow,TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"));
         
-        var timeDifference = CurrentTime - timeStampDateTime;
+        // Convert the parsed timestamp from UTC to local time (it's stored as UTC)
+        var localTimeStamp = TimeZoneInfo.ConvertTimeFromUtc(timeStampDateTime, TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"));
+        
+        var timeDifference = CurrentTime - localTimeStamp;
         
         if (timeDifference.TotalSeconds < 60)
         {

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -43,7 +43,10 @@ public class PublicModel : PageModel
         // Format the timestamp
         var CurrentTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow,TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"));
         
-        var timeDifference = CurrentTime - timeStampDateTime;
+        // Convert the parsed timestamp from UTC to local time (it's stored as UTC)
+        var localTimeStamp = TimeZoneInfo.ConvertTimeFromUtc(timeStampDateTime, TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"));
+        
+        var timeDifference = CurrentTime - localTimeStamp;
         
         if (timeDifference.TotalSeconds < 60)
         {

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -48,7 +48,10 @@ public class UserTimelineModel : PageModel
         // Format the timestamp
         var CurrentTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow,TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"));
         
-        var timeDifference = CurrentTime - timeStampDateTime;
+        // Convert the parsed timestamp from UTC to local time (it's stored as UTC)
+        var localTimeStamp = TimeZoneInfo.ConvertTimeFromUtc(timeStampDateTime, TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"));
+        
+        var timeDifference = CurrentTime - localTimeStamp;
         
         if (timeDifference.TotalSeconds < 60)
         {


### PR DESCRIPTION
**Timestamp formatting fixes:**

Updated `GetFormattedTimeStamp` in `CheepComment.cshtml.cs`, `PopularTimeline.cshtml.cs`, `Public.cshtml.cs`, and `UserTimeline.cshtml.cs` to convert UTC timestamps to Central European Standard Time before calculating time differences. Previously, UTC timestamps were subtracted directly from local time, producing incorrect relative times.

Fixes issue #30 

![20260301-1821-53 0443904-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/03d76b81-7635-4125-8c4c-ee9ea34bab88)
