### PR TITLE
Remove default Postgres host fallback

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,7 +81,7 @@ jobs:
       #   POSTGRES_PROD_USER:     PostgreSQL username for production database
       #   POSTGRES_PROD_PASSWORD: PostgreSQL password for production database
       #   POSTGRES_PROD_DB:       PostgreSQL database name for production database
-      #   POSTGRES_PROD_HOST:     PostgreSQL host (defaults to 'db' if not set, set to IP/hostname for external DB)
+      #   POSTGRES_PROD_HOST:     PostgreSQL host for production database
       - name: Deploy to Hetzner via SSH
         uses: appleboy/ssh-action@v1
         with:

--- a/prod-compose/docker-compose.devops-serv1.yml
+++ b/prod-compose/docker-compose.devops-serv1.yml
@@ -24,7 +24,7 @@ services:
       - ASPNETCORE_URLS=https://*:8081;http://*:8080
       - ASPNETCORE_Kestrel__Certificates__Default__Path=/cert/live/windysquirrels.dk/fullchain.pem
       - ASPNETCORE_Kestrel__Certificates__Default__KeyPath=/cert/live/windysquirrels.dk/privkey.pem
-      - ConnectionStrings__DefaultConnection=Host=${POSTGRES_PROD_HOST:-db};Database=${POSTGRES_PROD_DB};Username=${POSTGRES_PROD_USER};Password=${POSTGRES_PROD_PASSWORD}
+      - ConnectionStrings__DefaultConnection=Host=${POSTGRES_PROD_HOST};Database=${POSTGRES_PROD_DB};Username=${POSTGRES_PROD_USER};Password=${POSTGRES_PROD_PASSWORD}
     volumes:
       - /etc/letsencrypt:/cert
     ports:


### PR DESCRIPTION
This pull request makes minor adjustments to environment variable handling for the production PostgreSQL database configuration, ensuring that the database host must now be explicitly set rather than defaulting to a value.