### PR TITLE
Add Prometheus metrics

### DIFF
--- a/src/Chirp.Web/Chirp.Web.csproj
+++ b/src/Chirp.Web/Chirp.Web.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
+    <PackageReference Include="prometheus-net" Version="8.2.1" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <EmbeddedResource Include="../../data/**/*" />
   </ItemGroup>
 

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -5,6 +5,7 @@ using Chirp.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Chirp.Web.Middleware;
+using Prometheus;
 
 namespace Chirp.Web
 {
@@ -107,6 +108,9 @@ namespace Chirp.Web
             
             
 
+            // Use Prometheus middleware to expose metrics at /metrics
+            app.UseHttpMetrics();
+
             //Use CORS
             app.UseCors();
 
@@ -122,7 +126,10 @@ namespace Chirp.Web
             app.UseAuthorization();
 
             // Map Razor Pages
-            app.MapRazorPages(); 
+            app.MapRazorPages();
+            
+            // Expose metrics endpoint for Prometheus
+            app.MapMetrics();
             
             // Map Controllers (Used for Simulator API endpoints)
             app.MapControllers();


### PR DESCRIPTION
Adds support for Prometheus metrics

Dependencies added to `Chirp.Web.csproj`:
- `prometheus-net` - for `/metrics` endpoint
- `prometheus-net.AspNetCore` - for specific asp.net metrics.