### PR TITLE
Allow local access to /metrics in nginx proxy

### DIFF
--- a/prod-compose/nginx.conf
+++ b/prod-compose/nginx.conf
@@ -17,7 +17,18 @@ http {
         listen 80;
         server_name windysquirrels.dk;
 
-        return 301 https://$host$request_uri;
+        # Windysquirrels metrics endpoint.
+        location /metrics {
+            allow 127.0.0.1;     # Restrict access to localhost only.
+            allow 10.0.0.0/28;   # Restrict access to localhost only.
+            deny all;            # (Possible to add a dedicated scraper server IP later.)
+
+            proxy_pass http://cheep:8080/metrics;
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
     }
 
     server {
@@ -27,9 +38,9 @@ http {
         ssl_certificate     /etc/letsencrypt/live/windysquirrels.dk/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/windysquirrels.dk/privkey.pem;
 
-        # Windysquirrels metrics endpoint. 
+        # Windysquirrels metrics endpoint.
         location /metrics {
-            allow 127.0.0.1;     # Restrict access to localhost only. 
+            allow 127.0.0.1;     # Restrict access to localhost only.
             deny all;            # (Possible to add a dedicated scraper server IP later.)
 
             proxy_pass http://cheep:8080/metrics;


### PR DESCRIPTION
Updates the Nginx config for `windysquirrels.dk` to allow localhost (`127.0.0.1`) access to the existing `/metrics` endpoint, which was previously inaccessible.