### PR TITLE
Not running metrics updater during tests using IntegrationFixture.cs

### DIFF
--- a/prod-compose/docker-compose.devops-serv1.yml
+++ b/prod-compose/docker-compose.devops-serv1.yml
@@ -60,7 +60,6 @@ services:
     command: -config.file=/etc/promtail/config.yml
     depends_on:
       - nginx
-    restart: unless-stopped
 
 volumes:
   db_data:

--- a/prod-compose/docker-compose.devops-serv2.yml
+++ b/prod-compose/docker-compose.devops-serv2.yml
@@ -31,4 +31,3 @@ services:
       - /home/github/chirp/logging/loki:/etc/loki
       - /home/github/chirp/loki-data/loki:/loki
     command: -config.file=/etc/loki/loki-config.yml
-    restart: unless-stopped

--- a/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
+++ b/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.10.3" />
+        <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.11.0" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2">

--- a/test/Chirp.TestIntegration/IntegrationFixture.cs
+++ b/test/Chirp.TestIntegration/IntegrationFixture.cs
@@ -1,3 +1,5 @@
+using Chirp.Web;
+
 namespace Chirp.TestIntegration;
 
 public class IntegrationFixture : IDisposable
@@ -41,6 +43,14 @@ public class IntegrationFixture : IDisposable
                 {
                     options.UseNpgsql(_postgresContainer.GetConnectionString());
                 });
+
+                // Remove MetricsUpdater during tests
+                var descriptor = services.SingleOrDefault(
+                    d => d.ImplementationType == typeof(MetricsUpdater)
+                );
+
+                if (descriptor != null)
+                    services.Remove(descriptor);
             });
         });
 


### PR DESCRIPTION
Hi Spon

I have this fix to problems running integration tests. The hosted service was calling a disposed web app factory for a client instance by mistake, due to how the hosted service interacts. My solution is to not run the updater during these tests. 

This request also bumps the version of "Magick.NET-Q8-AnyCPU" to version 14.11.0 to keep up with security advisories. 

Please review this fix. Hopefully we can have BI on the `develop` branch very soon. 