### PR TITLE
Expose PostgreSQL port in docker-compose file

### DIFF
--- a/prod-compose/docker-compose.devops-serv1.yml
+++ b/prod-compose/docker-compose.devops-serv1.yml
@@ -5,6 +5,8 @@ services:
     image: postgres:15-alpine
     container_name: db
     restart: unless-stopped
+    ports:
+     - "10.0.0.3:5432:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_PROD_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PROD_PASSWORD}


### PR DESCRIPTION
As security measures:
- We have a firewall in front of the public IP.
- Postgres is configured to listen on select IP addresses only. 
- We only expose this port on our private network.