### PR TITLE
Addition to 2.1: Found and added LLM entries to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -20,3 +20,7 @@ Christian <chpj@itu.dk> KongCristi <christian.joergensen2@gmail.com>
 # Ronas
 Ronas <rono@itu.dk> Ronas Olsen <151834029+RonoITU@users.noreply.github.com>
 Ronas <rono@itu.dk> Ronas Olsen <rono@itu.dk>
+
+# GitHub Copilot
+LLM <none> GitHub Copilot <copilot@github.com>
+LLM <none> Copilot <175728472+Copilot@users.noreply.github.com>


### PR DESCRIPTION
These co-author entries do not get picked up by the classic shortlog cmd. Advice for how to search was easy to find online. https://willthompson.co.uk/notes/git-shortlog-co-authored-by/